### PR TITLE
Attempt to fix class path libraries for any contributor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/DaVizFrege/.classpath.base
+++ b/DaVizFrege/.classpath.base
@@ -6,6 +6,5 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="/Users/wesleygenizshann/.p2/pool/plugins/frege.ide_3.25.42/lib/fregec.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/DaVizFrege/.gitignore
+++ b/DaVizFrege/.gitignore
@@ -25,3 +25,6 @@ hs_err_pid*
 # 
 .settings/
 bin/
+
+# Eclipse
+.classpath

--- a/DaVizFrege/README.md
+++ b/DaVizFrege/README.md
@@ -10,9 +10,13 @@ the Frege implementation of Haskell running on the JVM. The project
 is an Eclipse project. A recent version of Java is required (Java 8 or
 higher), and the following plug-in is used:
 
-Frege Development	Version 3.24.93
+Frege Development	Version 3.25.42 
 
 This can be obtained from: https://github.com/Frege/eclipse-plugin
+
+# Getting started
+
+Before importing the project to Eclipse, copy the `.classpath.base` file and remove the `.base` extension.
 
 The project can be imported in the Eclipse workspace by File > Import
 select General > Existing Project... and select the
@@ -22,8 +26,7 @@ installed with EGit, and the selected sources are under source control,
 you may also commit changes from Eclipse.
 
 Due to the nature of the Frege plug-in, it may be necessary to delete
-a faulty reference to the Frege library, that points to a Windows path
-on the author's computer: context menu of DaVizFrege, select
+a faulty reference to the Frege library: context menu of DaVizFrege, select
 Properties and choose Java Build Path and the tab Libraries. Remove the
 offending fregec.jar reference. Afterwards, select the
 "Enable Frege Builder" action in the context menu of the project.

--- a/DaVizJava/.classpath.base
+++ b/DaVizJava/.classpath.base
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path=""/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="/Users/wesleygenizshann/.p2/pool/plugins/frege.ide_3.25.42/lib/fregec.jar"/>
-	<classpathentry kind="lib" path="/Users/wesleygenizshann/Documents/projects/eclipse-workspace/DaVizFrege/bin"/>
+	<classpathentry kind="lib" path="/DaVizFrege/bin"/>
 	<classpathentry kind="output" path=""/>
 </classpath>

--- a/DaVizJava/.gitignore
+++ b/DaVizJava/.gitignore
@@ -24,3 +24,6 @@ hs_err_pid*
 
 # 
 .settings/
+
+# Eclipse
+.classpath

--- a/DaVizJava/README.md
+++ b/DaVizJava/README.md
@@ -10,10 +10,16 @@ Please also see the accompanying technical report for an overview
 of this project. This file will only contain information regarding
 the build of a deployable software artifact.
 
+# Getting started
+
 This project is built using Eclipse. The project depends on the
 Frege project (DaVizFrege), and every time a change in the Frege
 sources occurs, this project needs to be refreshed to expose the
 compiled sources to the Swing project (DaViz).
+
+Before importing the project to Eclipse, copy the `.classpath.base` file and remove the `.base` extension.
+
+To add the Frege dependence, select the `Enable Frege Builder` action in the context menu of the project.
 
 It may be necessary to readd the DaVizFrege project to the classpath.
 Open the Properties (context menu and select Properties...) and navigate


### PR DESCRIPTION
### Description

Fixes #1

Given the nature of the Frege plugin, copying the Frege JAR to a relative path inside the project such as `DaVizFrege/lib/frege.jar` is not possible, as it breaks the project. 

As such, one quick fix is to stop tracking the `.classpath` file and instead provide a base file `.classpath.base`, that contributors can simply copy the file, remove the extension and add the Frege dependence via `Enable Frege Builder`.

I verified that the DaVizFrege reference can be included via adding `Local class folder`, which takes an imported Java project in the workplace.

This is not the prettiest solution, but I believe it works for now since the absolute path is not tracked anymore.

