### PR TITLE
[#25] Fix UndefinedState label to `Undefined`

### DIFF
--- a/SimulationCore/src/com/aexiz/daviz/simulation/algorithm/information/state/UndefinedState.java
+++ b/SimulationCore/src/com/aexiz/daviz/simulation/algorithm/information/state/UndefinedState.java
@@ -2,6 +2,6 @@ package com.aexiz.daviz.simulation.algorithm.information.state;
 
 public class UndefinedState extends AbstractState {
     public UndefinedState() {
-        super("Initiator");
+        super("Undefined");
     }
 }


### PR DESCRIPTION
# Description

closes #25 

Ensure to display `Undefined` state for non-initiator processes in the Information windows when clicking in a process in the Network windows.

### PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

### Updated port

- [x] Java
- [x] Frege

### Updated modules

- [ ] Assets
- [x] Simulation Core
- [ ] Simulation Frege
- [ ] Simulation Java
- [ ] Test 
- [ ] UI Swing
